### PR TITLE
update the gem to not be SM specific and be more reusable; update test

### DIFF
--- a/lib/sidekiq/cloud_watch_metrics.rb
+++ b/lib/sidekiq/cloud_watch_metrics.rb
@@ -42,7 +42,7 @@ module Sidekiq::CloudWatchMetrics
       include Sidekiq::Component
     end
 
-    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new(region: 'us-west-2'), namespace: ENV.fetch('NAMESPACE', 'Default-Sidekiq-CloudWatchMetrics'), process_metrics: true, additional_dimensions: {}, metrics_to_publish: nil, interval: 60)
+    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new(region: 'us-west-2'), namespace: ENV.fetch('NAMESPACE', 'Default-Sidekiq-CloudWatchMetrics'), process_metrics: true, additional_dimensions: {}, interval: 60, **kwargs)
       # Sidekiq 6.5+ requires @config, which defaults to the top-level
       # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
       @config = config
@@ -50,7 +50,7 @@ module Sidekiq::CloudWatchMetrics
       @namespace = namespace
       @process_metrics = process_metrics
       @additional_dimensions = additional_dimensions.map { |k, v| {name: k.to_s, value: v.to_s} }
-      @metrics_to_publish = metrics_to_publish
+      @metrics_to_publish = kwargs[:metrics_to_publish] || []
       @interval = interval
     end
 

--- a/lib/sidekiq/cloud_watch_metrics.rb
+++ b/lib/sidekiq/cloud_watch_metrics.rb
@@ -42,7 +42,7 @@ module Sidekiq::CloudWatchMetrics
       include Sidekiq::Component
     end
 
-    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new(region: 'us-west-2'), namespace: ENV.fetch('NAMESPACE', 'Default-Sidekiq-CloudWatchMetrics'), process_metrics: true, additional_dimensions: {}, metrics_to_publish: %w[EnqueuedJobs], interval: 60)
+    def initialize(config: Sidekiq, client: Aws::CloudWatch::Client.new(region: 'us-west-2'), namespace: ENV.fetch('NAMESPACE', 'Default-Sidekiq-CloudWatchMetrics'), process_metrics: true, additional_dimensions: {}, metrics_to_publish: nil, interval: 60)
       # Sidekiq 6.5+ requires @config, which defaults to the top-level
       # `Sidekiq` module, but can be overridden when running multiple Sidekiqs.
       @config = config
@@ -228,12 +228,13 @@ module Sidekiq::CloudWatchMetrics
           metric[:dimensions] = (metric[:dimensions] || []) + @additional_dimensions
         end
       end
-
       # We can only put 20 metrics at a time
-      metrics.select { |metric| @metrics_to_publish.include?(metric[:metric_name]) }.each_slice(20) do |some_metrics|
+      custom_metrics = @metrics_to_publish&.any? ? metrics.select { |metric| @metrics_to_publish.include?(metric[:metric_name]) } : metrics
+
+      custom_metrics.each_slice(20) do |metric_to_publish|
         @client.put_metric_data(
           namespace: @namespace,
-          metric_data: some_metrics,
+          metric_data: metric_to_publish,
           )
       end
     end

--- a/spec/sidekiq/cloud_watch_metrics_spec.rb
+++ b/spec/sidekiq/cloud_watch_metrics_spec.rb
@@ -200,15 +200,19 @@ RSpec.describe Sidekiq::CloudWatchMetrics do
       end
 
       context "when per process metrics are disabled" do
-        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, process_metrics: false) }
+        subject(:publisher) { Sidekiq::CloudWatchMetrics::Publisher.new(client: client, process_metrics: false, metrics_to_publish: ['Utilization']) }
 
         it "only publishes a single Utilization metric" do
           Timecop.freeze(now = Time.now) do
+            allow(client).to receive(:put_metric_data)
+
             publisher.publish
 
+            expect(client).to have_received(:put_metric_data).with(namespace: 'NAMESPACE', metric_data: [{ metric_name: 'Utilization', timestamp: Time.now, unit: 'Percent', value: 30.0 }])
           end
         end
       end
+
     end
 
     describe "#stop" do


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/devops-14438)

## Purpose 
<!-- what/why -->
update the gem to not be SM specific and be more reusable; update test
## Approach 
<!-- how -->
revert changes that made it specific to SM
Add kwargs to initialize method and pull metrics_to_publish from kwargs (don't need wrapper in platform-sdk)
Allow custom metrics to be passed and if not passed publish all original metrics
Line 232 orginally Paul and I had @metrics_to_publish.present? and I changed to @metrics_to_publish&.any? in order to evaluate for nil and an array
## Testing
<!-- what did you do to confirm this works/what would a QA engineer do to confirm - Think: setup process, steps, expected outcomes -->
tested locally: 
not passing a metric will publish all of them `Sidekiq::CloudWatchMetrics.enable!`
or pass metrics as array `Sidekiq::CloudWatchMetrics.enable!(metrics_to_publish: %w[EnqueuedJobs ScheduledJobs Workers Processes Utilization])`
rpec passes
## Screenshots/Video
<!-- show before/after of the change if possible -->
![image](https://github.com/StrongMind/sidekiq-cloudwatchmetrics/assets/101292749/1465de17-12db-4eda-b0f1-6dcc43bc6fa5)
![image](https://github.com/StrongMind/sidekiq-cloudwatchmetrics/assets/101292749/8cd2645f-8343-4c8d-b67e-77af5f070495)
![image](https://github.com/StrongMind/sidekiq-cloudwatchmetrics/assets/101292749/181f7ad6-52c1-4fef-9aa4-8f2da1000660)
