### PR TITLE
BEl-3425 Fix highest_latency_metric

### DIFF
--- a/lib/sidekiq/cloud_watch_metrics.rb
+++ b/lib/sidekiq/cloud_watch_metrics.rb
@@ -223,7 +223,9 @@ module Sidekiq::CloudWatchMetrics
         }
       end
 
-      highest_latency_metric = metrics.max_by { |metric| metric[:value] }
+      highest_latency_metric = metrics.select { |metric| metric[:name] == 'QueueLatency' }
+                                .max_by { |metric| metric[:value] }
+
       metrics << {
         metric_name: "MaxQueueLatency",
         dimensions: [{name: "QueueName", value: "AllQueues"}],


### PR DESCRIPTION
[Link to Jira ticket](https://strongmind.atlassian.net/browse/bel-3425)

## Purpose 
<!-- what/why -->
Fix highest_latency_metric
## Approach 
<!-- how -->
Only select metrics from the QueueLatency queue

